### PR TITLE
Add check for '(' before trying to make substring

### DIFF
--- a/src/Components/Generators/ModularDoc.Composer.Basic/Helpers/TypeHelpers.fs
+++ b/src/Components/Generators/ModularDoc.Composer.Basic/Helpers/TypeHelpers.fs
@@ -139,7 +139,10 @@ module internal TypeHelpers =
 
     let cutMethod() = 
       // Remove the namespace and declaring type
-      reference.Substring(reference.AsSpan(0, reference.IndexOf('(')).LastIndexOf('.') + 1)
+      if reference.IndexOf('(') <> -1 then
+        reference.Substring(reference.AsSpan(0, reference.IndexOf('(')).LastIndexOf('.') + 1)
+      else
+        reference.Substring(reference.AsSpan().LastIndexOf('.') + 1)
     let cutMember() = 
       // Remove the namespace and declaring type
       reference.Substring(reference.LastIndexOf('.') + 1)


### PR DESCRIPTION
Modifed the "cutMethod" function to add a check if the character '(' exists at all, before attempting to make a substring with it or not. I encountered this issue while it was processing "M:SolidShineUi.FlatWindow.DisableMinimizeAction" in my code's XML file.

It seems to me that C#'s XmlDoc doesn't mind if you include the parantheses or not for a function that has no arguments.

If you want to test this yourself, you can try downloading the compiled DLL and files from the [latest release of my library](https://github.com/JaykeBird/ssui/releases/tag/1.9.4). I was trying the net6.0-windows version. The line in question is line 494 in the documentation XML file included with my library.

I encountered another bug while trying to generate the documentation, which I'll cover in another issue.